### PR TITLE
Disable FBOSS OSS tests in on-diff jobs (#37)

### DIFF
--- a/build/fbcode_builder/manifests/fboss
+++ b/build/fbcode_builder/manifests/fboss
@@ -45,3 +45,6 @@ nlohmann-json
 fbcode/fboss/github = .
 fbcode/fboss/common = common
 fbcode/fboss = fboss
+
+[sandcastle]
+run_tests = off


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexperimental/rust-shed/pull/37

X-link: https://github.com/facebook/hhvm/pull/9317

X-link: https://github.com/facebookexperimental/edencommon/pull/6

X-link: https://github.com/facebookincubator/hsthrift/pull/108

X-link: https://github.com/facebook/proxygen/pull/436

X-link: https://github.com/facebookincubator/katran/pull/183

X-link: https://github.com/facebook/openr/pull/143

X-link: https://github.com/facebook/fbthrift/pull/536

X-link: https://github.com/facebook/fb303/pull/33

X-link: https://github.com/facebook/folly/pull/1924

FBOSS OSS on-diff job is failing due to random test failures.

Disabling the tests for now to avoid build breakages.

Reviewed By: shri-khare

Differential Revision: D42550176

