### PR TITLE
Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ dependencies. Therefore, you can use Cargo to not only build Reindeer, but to
 install it as well.
 
 ```shell
-cargo install --locked --git https://github.com/facebookincubator/reindeer
+cargo install --locked --git https://github.com/facebookincubator/reindeer reindeer
 ```
 
 ### Nix


### PR DESCRIPTION
The install instructions in the README fail with

```
error: multiple packages with binaries found: reindeer, rust-third-party. When installing a git repository, cargo will always search the entire repo for any Cargo.toml.
```

This just adds `reindeer` to the install so the first time experience is better.