### PR TITLE
Remove pointless comparison

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -747,10 +747,7 @@ fn parse_source(source: &str) -> Option<Source> {
         if let Some((repo, reference)) = address.split_once('?') {
             Some(Source::Git {
                 repo: repo.to_owned(),
-                reference: if let Some(rev) = reference.strip_prefix("rev=") {
-                    if rev != commit_hash {
-                        return None;
-                    }
+                reference: if reference.starts_with("rev=") {
                     GitRef::Revision
                 } else if let Some(branch) = reference.strip_prefix("branch=") {
                     GitRef::Branch(branch.to_owned())
@@ -770,5 +767,22 @@ fn parse_source(source: &str) -> Option<Source> {
         }
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{parse_source, Source};
+
+    #[test]
+    fn parses_sources() {
+        assert_eq!(
+            parse_source("git+https://github.com/EmbarkStudios/speedy?rev=1a2ec91#1a2ec91aa42fdfe1e2a239b93eafe367f5483b02").unwrap(),
+            Source::Git {
+                repo: "https://github.com/EmbarkStudios/speedy".into(),
+                reference: super::GitRef::Revision,
+                commit_hash: "1a2ec91aa42fdfe1e2a239b93eafe367f5483b02".into(),
+            }
+        );
     }
 }


### PR DESCRIPTION
When parsing the cargo sources the code was comparing the rev specified by the user to the full sha-1 commit hash that cargo locked the git repository to. This would cause reindeer buckify to fail if the user specified a short (7+) hash, a common practice. This check is really rather pointless, as the commit hash is the only thing that truly matters, and if the user did in fact specify an ambiguous/incorrect hash, short or otherwise, cargo would fail to get the correct full sha-1 commit hash anyways, something that reindeer itself need not handle, nor care about, at least in this context.