### PR TITLE
Remove github restriction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,7 +1108,6 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "rayon",
- "regex",
  "rustsec",
  "semver",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,9 +467,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
@@ -598,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -781,12 +781,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matches"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
-
-[[package]]
 name = "measure_time"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,9 +944,9 @@ checksum = "877630b3de15c0b64cc52f659345724fbf6bdad9bd9566699fc53688f3c34a34"
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pkg-config"
@@ -1097,6 +1091,7 @@ dependencies = [
  "anyhow",
  "dunce",
  "env_logger",
+ "fnv",
  "globset",
  "ignore",
  "indexmap",
@@ -1120,6 +1115,7 @@ dependencies = [
  "termcolor",
  "toml 0.7.3",
  "unicode-ident",
+ "url",
  "walkdir",
 ]
 
@@ -1675,12 +1671,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.4"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
-dependencies = [
- "matches",
-]
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
@@ -1690,9 +1683,9 @@ checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
@@ -1736,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 anyhow = "1.0.71"
 dunce = "1.0.2"
 env_logger = "0.10"
+fnv = "1.0"
 globset = { version = "0.4.13", features = ["serde1"] }
 ignore = "0.4"
 indexmap = { version = "1.9.2", features = ["arbitrary", "rayon", "serde-1"] }
@@ -42,6 +43,7 @@ syn = { version = "2.0.23", features = [
 termcolor = "1.0"
 toml = "0.7.3"
 unicode-ident = "1.0.10"
+url = "2.4"
 walkdir = "2.3"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,15 +22,23 @@ nom = "7.1"
 once_cell = "1.12"
 proc-macro2 = { version = "1.0.64", features = ["span-locations"] }
 rayon = "1.2"
-regex = "1.9.2"
 rustsec = { version = "0.26", features = ["fix"] }
 semver = { version = "1.0.17", features = ["serde"] }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
-serde_json = { version = "1.0.100", features = ["float_roundtrip", "unbounded_depth"] }
+serde_json = { version = "1.0.100", features = [
+    "float_roundtrip",
+    "unbounded_depth",
+] }
 serde_starlark = "0.1.13"
 structopt = "0.3.23"
 strum = { version = "0.24", features = ["derive"] }
-syn = { version = "2.0.23", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+syn = { version = "2.0.23", features = [
+    "extra-traits",
+    "fold",
+    "full",
+    "visit",
+    "visit-mut",
+] }
 termcolor = "1.0"
 toml = "0.7.3"
 unicode-ident = "1.0.10"

--- a/src/buckify.rs
+++ b/src/buckify.rs
@@ -289,6 +289,11 @@ fn generate_git_fetch(repo: &str, commit_hash: &str) -> Result<Rule> {
 
 /// Create a uniquely hashed directory name for the arbitrary source url
 pub fn short_name_for_git_repo(repo: &str) -> Result<String> {
+    anyhow::ensure!(
+        repo.starts_with("https://"),
+        "only https git urls are supported"
+    );
+
     // The strategy here is similar to what cargo does to generate a unique directory name
     // for git sources
     let mut sanitized = repo.to_lowercase();


### PR DESCRIPTION
This removes the github.com restriction for `vendor = false` git sources by employing a strategy similar to cargo for uniquely naming arbitrary git source urls. The url is normalized so it is consistently hashed, then combined with the last path component (for most hosted git providers, the name of the repo/project) + `-` + the hex hash of the normalized url. 