### PR TITLE
: don't panic in relative_path

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,9 +12,7 @@ jobs:
         os: [ubuntu, macos, windows]
     steps:
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-      - run: echo CARGO_HOME=$GITHUB_WORKSPACE/.cargo >> $GITHUB_ENV
-        shell: bash
+      # - uses: Swatinem/rust-cache@v2
       - run: cargo build --locked
       - run: cargo test
       - run: |-

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,5 +13,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
+      - run: echo CARGO_HOME=$GITHUB_WORKSPACE/.cargo >> $GITHUB_ENV
+        shell: bash
       - run: cargo build --locked
       - run: cargo test
+      - run: |-
+          cd example
+          ./setup.sh # run reindeer buckify
+          cat ./third-party/BUCK
+        shell: bash

--- a/example/setup.sh
+++ b/example/setup.sh
@@ -19,4 +19,4 @@ set -e
 # typically commit these fixups and the generated third-party/BUCK in the same
 # commit as above.
 
-../target/debug/reindeer --third-party-dir third-party buckify
+RUST_LOG="debug" ../target/debug/reindeer --third-party-dir third-party buckify

--- a/example/setup.sh
+++ b/example/setup.sh
@@ -4,19 +4,19 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-# Set up vendored directory
+# Generate file 'example/third-party/BUCK'.
 
 set -e
 
 (cd ..; cargo build)
 
-# Vendor the crates into third-party/vendor
-# This will resolve all the dependencies, and create or update third-party/Cargo.lock as required.
-# Typically you would then checkin Cargo.lock and all the vendored code in third-party/vendor
-../target/debug/reindeer --third-party-dir third-party vendor
-
 # Build a BUCK file to build third-party crates.
-# This is separate from vendoring as you may need to run it a few times if it reports needing a fixup.
-# It will create a template fixup.toml which you can edit as needed. You would typically commit
-# these fixups and the generated third-party/BUCK in the same commit as above.
+#
+# This will resolve all the dependencies, and create or update
+# third-party/Cargo.lock as required.
+#
+# It will create a template fixup.toml which you can edit as needed. You would
+# typically commit these fixups and the generated third-party/BUCK in the same
+# commit as above.
+
 ../target/debug/reindeer --third-party-dir third-party buckify

--- a/src/buckify.rs
+++ b/src/buckify.rs
@@ -114,7 +114,30 @@ pub fn relative_path(mut base: &Path, to: &Path) -> PathBuf {
             res.display()
         );
         res.push("..");
-        base = base.parent().expect("root dir not prefix of other?");
+        base.parent().expect("root not prefix of other?")
+        /*
+            match base.parent() {
+                Some(parent) => base = parent,
+                None => {
+                    // Here, `to` and `base` do not share a common
+                    // ancestor.
+
+                    // Example:
+                    //  - `to`   = 'C:\Users\runneradmin\.cargo\...001f\anyhow-1.0.79\build.rs'
+                    //  - `base` = 'D:\a\reindeer\reindeer\shim\third-party\rust'
+
+                    // In this case return `to` "as-is" (i.e. without any
+                    // modification)`. `reindeer buckify` seems to work
+                    // with this choice.
+                    log::debug!(
+                        "relative_path: no common ancestor. returning to={}",
+                        to.display(),
+                    );
+
+                    return to.to_path_buf();
+                }
+        }
+            */
     }
 
     res.join(


### PR DESCRIPTION
Summary: if in `relative_path` we find `to` and `from` are in different file systems, don't panic but instead just return `to` unmodified. testing indicates that `reindeer buckify` continues to work as normal with that choice in this case.

Differential Revision:
D52989646

Privacy Context Container: L1122763


