### PR TITLE
add libc fixup

### DIFF
--- a/example/third-party/fixups/libc/fixups.toml
+++ b/example/third-party/fixups/libc/fixups.toml
@@ -1,0 +1,2 @@
+[[buildscript]]
+[buildscript.rustc_flags]


### PR DESCRIPTION
fixes warning
```
[WARN  reindeer::fixups] libc-0.2.153 has a build script, but I don't know what to do with it: Unresolved build script at ../../../../.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.153/build.rs.
```