### PR TITLE
Middle-ground vendoring option using a local registry

### DIFF
--- a/src/buck.rs
+++ b/src/buck.rs
@@ -449,7 +449,7 @@ impl Serialize for HttpArchive {
 }
 
 #[derive(Debug)]
-pub struct CompressedCrate {
+pub struct ExtractArchive {
     pub name: Name,
     pub src: BuckPath,
     pub strip_prefix: String,
@@ -458,7 +458,7 @@ pub struct CompressedCrate {
     pub sort_key: Name,
 }
 
-impl Serialize for CompressedCrate {
+impl Serialize for ExtractArchive {
     fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
         let Self {
             name,
@@ -1057,7 +1057,7 @@ impl Serialize for PrebuiltCxxLibrary {
 pub enum Rule {
     Alias(Alias),
     Filegroup(Filegroup),
-    ExtractArchive(CompressedCrate),
+    ExtractArchive(ExtractArchive),
     HttpArchive(HttpArchive),
     GitFetch(GitFetch),
     Binary(RustBinary),
@@ -1099,7 +1099,7 @@ fn rule_sort_key(rule: &Rule) -> impl Ord + '_ {
         // Make the alias rule come before the actual rule. Note that aliases
         // emitted by reindeer are always to a target within the same package.
         Rule::Alias(Alias { actual, .. }) => RuleSortKey::Other(actual, 0),
-        Rule::ExtractArchive(CompressedCrate { sort_key, .. }) => RuleSortKey::Other(sort_key, 1),
+        Rule::ExtractArchive(ExtractArchive { sort_key, .. }) => RuleSortKey::Other(sort_key, 1),
         Rule::HttpArchive(HttpArchive { sort_key, .. }) => RuleSortKey::Other(sort_key, 1),
         Rule::GitFetch(GitFetch { name, .. }) => RuleSortKey::GitFetch(name),
         Rule::Filegroup(_)
@@ -1125,7 +1125,7 @@ impl Rule {
             Rule::Alias(Alias { name, .. })
             | Rule::Filegroup(Filegroup { name, .. })
             | Rule::HttpArchive(HttpArchive { name, .. })
-            | Rule::ExtractArchive(CompressedCrate { name, .. })
+            | Rule::ExtractArchive(ExtractArchive { name, .. })
             | Rule::GitFetch(GitFetch { name, .. })
             | Rule::Binary(RustBinary {
                 common:

--- a/src/buck.rs
+++ b/src/buck.rs
@@ -452,7 +452,6 @@ impl Serialize for HttpArchive {
 pub struct CompressedCrate {
     pub name: Name,
     pub src: BuckPath,
-    pub sha256: String,
     pub strip_prefix: String,
     pub sub_targets: BTreeSet<BuckPath>,
     pub visibility: Visibility,
@@ -464,7 +463,6 @@ impl Serialize for CompressedCrate {
         let Self {
             name,
             src,
-            sha256,
             strip_prefix,
             sub_targets,
             visibility,
@@ -473,7 +471,6 @@ impl Serialize for CompressedCrate {
         let mut map = ser.serialize_map(None)?;
         map.serialize_entry("name", name)?;
         map.serialize_entry("src", src)?;
-        map.serialize_entry("sha256", sha256)?;
         map.serialize_entry("strip_prefix", strip_prefix)?;
         if !sub_targets.is_empty() {
             map.serialize_entry("sub_targets", sub_targets)?;

--- a/src/buckify.rs
+++ b/src/buckify.rs
@@ -262,7 +262,7 @@ fn generate_nonvendored_sources_archive<'scope>(
         Source::Local => Ok(None),
         Source::CratesIo => match context.config.vendor {
             VendorConfig::Off => generate_http_archive(context, pkg, lockfile_package).map(Some),
-            VendorConfig::Compressed => {
+            VendorConfig::LocalRegistry => {
                 generate_extract_archive(context, pkg, lockfile_package).map(Some)
             }
             VendorConfig::Source(_) => unreachable!(),

--- a/src/buckify.rs
+++ b/src/buckify.rs
@@ -281,29 +281,14 @@ fn generate_nonvendored_sources_archive<'scope>(
 }
 
 fn generate_extract_archive<'scope>(
-    context: &'scope RuleContext<'scope>,
+    _context: &'scope RuleContext<'scope>,
     pkg: &'scope Manifest,
-    lockfile_package: &LockfilePackage,
+    _lockfile_package: &LockfilePackage,
 ) -> anyhow::Result<Rule> {
-    let sha256 = match &lockfile_package.checksum {
-        Some(checksum) => checksum.clone(),
-        None => {
-            // Dependencies from Source::CratesIo should almost certainly be
-            // associated with a checksum so a failure here is not expected.
-            bail!(
-                "No sha256 checksum available for \"{}\" {} in lockfile {}",
-                pkg.name,
-                pkg.version,
-                context.paths.lockfile_path.display(),
-            );
-        }
-    };
-
     let vendordir = "vendor";
 
     Ok(Rule::ExtractArchive(CompressedCrate {
         name: Name(format!("{}-{}.crate", pkg.name, pkg.version)),
-        sha256,
         src: BuckPath(PathBuf::from(format!(
             "{vendordir}/{}-{}.crate",
             pkg.name, pkg.version

--- a/src/buckify.rs
+++ b/src/buckify.rs
@@ -33,7 +33,7 @@ use crate::buck;
 use crate::buck::Alias;
 use crate::buck::BuckPath;
 use crate::buck::Common;
-use crate::buck::CompressedCrate;
+use crate::buck::ExtractArchive;
 use crate::buck::Filegroup;
 use crate::buck::GitFetch;
 use crate::buck::HttpArchive;
@@ -287,7 +287,7 @@ fn generate_extract_archive<'scope>(
 ) -> anyhow::Result<Rule> {
     let vendordir = "vendor";
 
-    Ok(Rule::ExtractArchive(CompressedCrate {
+    Ok(Rule::ExtractArchive(ExtractArchive {
         name: Name(format!("{}-{}.crate", pkg.name, pkg.version)),
         src: BuckPath(PathBuf::from(format!(
             "{vendordir}/{}-{}.crate",

--- a/src/buckify.rs
+++ b/src/buckify.rs
@@ -269,7 +269,14 @@ fn generate_nonvendored_sources_archive<'scope>(
         },
         Source::Git {
             repo, commit_hash, ..
-        } => generate_git_fetch(repo, commit_hash).map(Some),
+        } => match context.config.vendor {
+            VendorConfig::Off => generate_git_fetch(repo, commit_hash).map(Some),
+            VendorConfig::LocalRegistry => {
+                generate_extract_archive_git(context, pkg, lockfile_package, repo, commit_hash)
+                    .map(Some)
+            }
+            VendorConfig::Source(_) => unreachable!(),
+        },
         Source::Unrecognized(_) => {
             bail!(
                 "`vendor = false` mode is supported only with exclusively crates.io and https git dependencies. \"{}\" {} is coming from some other source",
@@ -286,9 +293,34 @@ fn generate_extract_archive<'scope>(
     _lockfile_package: &LockfilePackage,
 ) -> anyhow::Result<Rule> {
     let vendordir = "vendor";
-
     Ok(Rule::ExtractArchive(ExtractArchive {
         name: Name(format!("{}-{}.crate", pkg.name, pkg.version)),
+        src: BuckPath(PathBuf::from(format!(
+            "{vendordir}/{}-{}.crate",
+            pkg.name, pkg.version
+        ))),
+        strip_prefix: format!("{}-{}", pkg.name, pkg.version),
+        sub_targets: BTreeSet::new(), // populated later after all fixups are constructed
+        visibility: Visibility::Private,
+        sort_key: Name(format!("{}-{}", pkg.name, pkg.version)),
+    }))
+}
+
+fn generate_extract_archive_git<'scope>(
+    _context: &'scope RuleContext<'scope>,
+    pkg: &'scope Manifest,
+    _lockfile_package: &LockfilePackage,
+    repo: &str,
+    _commit_hash: &str,
+) -> anyhow::Result<Rule> {
+    let vendordir = "vendor";
+    let short_name = short_name_for_git_repo(repo)?;
+    Ok(Rule::ExtractArchive(ExtractArchive {
+        name: Name(format!("{}.git", short_name)),
+        //
+        // Would be nice if cargo local-registry wrote out a git-related name instead
+        // of `mycrate-0.1.0.crate`. However it does not.
+        //
         src: BuckPath(PathBuf::from(format!(
             "{vendordir}/{}-{}.crate",
             pkg.name, pkg.version
@@ -445,7 +477,12 @@ fn generate_target_rules<'scope>(
         if context.config.vendor.is_source() || matches!(pkg.source, Source::Local) {
             relative_path(&paths.third_party_dir, manifest_dir)
         } else if let Source::Git { repo, .. } = &pkg.source {
-            let git_fetch = short_name_for_git_repo(repo)?;
+            let mut git_fetch = short_name_for_git_repo(repo)?;
+            if matches!(context.config.vendor, VendorConfig::LocalRegistry) {
+                // Subtle difference -- git_fetch rules will strip the `.git` off the name
+                // when used as a dependency. extract_archive will not.
+                git_fetch += ".git";
+            }
             let repository_root = find_repository_root(manifest_dir)?;
             let path_within_repo = relative_path(repository_root, manifest_dir);
             PathBuf::from(git_fetch).join(path_within_repo)

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -61,7 +61,7 @@ pub fn cargo_get_lockfile_and_metadata(
 
     let cargo_home;
     let lockfile;
-    if config.vendor.is_none() {
+    if config.vendor.is_not_source() {
         cargo_home = None;
 
         // Whether or not there is a Cargo.lock already, do not read it yet.

--- a/src/config.rs
+++ b/src/config.rs
@@ -156,7 +156,7 @@ pub struct BuckConfig {
 #[serde(deny_unknown_fields)]
 pub enum VendorConfig {
     Off,
-    Compressed,
+    LocalRegistry,
     Source(VendorSourceConfig),
 }
 impl VendorConfig {
@@ -318,8 +318,8 @@ where
         where
             E: serde::de::Error,
         {
-            if v == "compressed" {
-                Ok(VendorConfig::Compressed)
+            if v == "local-registry" {
+                Ok(VendorConfig::LocalRegistry)
             } else {
                 Err(E::custom("unknown vendor type"))
             }

--- a/src/fixups.rs
+++ b/src/fixups.rs
@@ -42,6 +42,7 @@ use crate::cargo::NodeDepKind;
 use crate::cargo::Source;
 use crate::collection::SetOrMap;
 use crate::config::Config;
+use crate::config::VendorConfig;
 use crate::glob::Globs;
 use crate::glob::SerializableGlobSet as GlobSet;
 use crate::glob::NO_EXCLUDE;
@@ -882,6 +883,11 @@ impl<'meta> Fixups<'meta> {
                                 &self.third_party_dir,
                                 self.manifest_dir,
                             )))
+                        } else if let VendorConfig::LocalRegistry = self.config.vendor {
+                            StringOrPath::String(format!(
+                                "{}-{}.crate",
+                                self.package.name, self.package.version,
+                            ))
                         } else if let Source::Git { repo, .. } = &self.package.source {
                             let short_name = short_name_for_git_repo(repo)?;
                             StringOrPath::String(short_name.to_owned())

--- a/src/fixups.rs
+++ b/src/fixups.rs
@@ -166,7 +166,7 @@ impl<'meta> Fixups<'meta> {
         &self,
         relative_to_manifest_dir: &Path,
     ) -> anyhow::Result<SubtargetOrPath> {
-        if self.config.vendor.is_some() || matches!(self.package.source, Source::Local) {
+        if self.config.vendor.is_source() || matches!(self.package.source, Source::Local) {
             // Path to vendored file looks like "vendor/foo-1.0.0/src/lib.rs"
             let manifest_dir = relative_path(&self.third_party_dir, self.manifest_dir);
             let path = manifest_dir.join(relative_to_manifest_dir);
@@ -311,7 +311,7 @@ impl<'meta> Fixups<'meta> {
         };
 
         for fix in fixes {
-            if self.config.vendor.is_none() {
+            if self.config.vendor.is_not_source() {
                 if let Source::Git { repo, .. } = &self.package.source {
                     // Cxx_library fixups only work if the sources are vendored
                     // or from an http_archive. They do not work with sources
@@ -875,7 +875,7 @@ impl<'meta> Fixups<'meta> {
             for cargo_env in config.cargo_env.iter() {
                 let v = match cargo_env {
                     CargoEnv::CARGO_MANIFEST_DIR => {
-                        if self.config.vendor.is_some()
+                        if self.config.vendor.is_source()
                             || matches!(self.package.source, Source::Local)
                         {
                             StringOrPath::Path(BuckPath(relative_path(
@@ -936,7 +936,7 @@ impl<'meta> Fixups<'meta> {
 
         // This function is only used in vendoring mode, so it's guaranteed that
         // manifest_dir is a subdirectory of third_party_dir.
-        assert!(self.config.vendor.is_some() || matches!(self.package.source, Source::Local));
+        assert!(self.config.vendor.is_source() || matches!(self.package.source, Source::Local));
         let manifest_rel = relative_path(&self.third_party_dir, self.manifest_dir);
 
         let srcs_globs: Vec<String> = srcs

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,7 +148,7 @@ fn try_main() -> anyhow::Result<()> {
 
         SubCommand::Buckify { stdout } => {
             match &config.vendor {
-                VendorConfig::Compressed | VendorConfig::Source(..)
+                VendorConfig::LocalRegistry | VendorConfig::Source(..)
                     if !vendor::is_vendored(&config, &paths)? =>
                 {
                     // If you ran `reindeer buckify` without `reindeer vendor`, then

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,10 +147,15 @@ fn try_main() -> anyhow::Result<()> {
         }
 
         SubCommand::Buckify { stdout } => {
-            if config.vendor.is_source() && !vendor::is_vendored(&paths)? {
-                // If you ran `reindeer buckify` without `reindeer vendor`, then
-                // default to generating non-vendored targets.
-                config.vendor = VendorConfig::Off;
+            match &config.vendor {
+                VendorConfig::Compressed | VendorConfig::Source(..)
+                    if !vendor::is_vendored(&config, &paths)? =>
+                {
+                    // If you ran `reindeer buckify` without `reindeer vendor`, then
+                    // default to generating non-vendored targets.
+                    config.vendor = VendorConfig::Off;
+                }
+                _ => {}
             }
             buckify::buckify(&config, &args, &paths, *stdout)?;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,8 @@ use std::path::PathBuf;
 use clap::Parser;
 use clap::Subcommand;
 
+use crate::config::VendorConfig;
+
 mod audit_sec;
 mod buck;
 mod buckify;
@@ -145,10 +147,10 @@ fn try_main() -> anyhow::Result<()> {
         }
 
         SubCommand::Buckify { stdout } => {
-            if config.vendor.is_some() && !vendor::is_vendored(&paths)? {
+            if config.vendor.is_source() && !vendor::is_vendored(&paths)? {
                 // If you ran `reindeer buckify` without `reindeer vendor`, then
                 // default to generating non-vendored targets.
-                config.vendor = None;
+                config.vendor = VendorConfig::Off;
             }
             buckify::buckify(&config, &args, &paths, *stdout)?;
         }

--- a/src/remap.rs
+++ b/src/remap.rs
@@ -11,13 +11,13 @@ use std::path::PathBuf;
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct RemapConfig {
     #[serde(rename = "source", default)]
     pub sources: Map<String, RemapSource>,
 }
 
-#[derive(Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 pub struct RemapSource {
     pub directory: Option<PathBuf>,
     pub git: Option<String>,
@@ -26,4 +26,6 @@ pub struct RemapSource {
     pub tag: Option<String>,
     #[serde(rename = "replace-with")]
     pub replace_with: Option<String>,
+    #[serde(rename = "local-registry")]
+    pub local_registry: Option<String>,
 }

--- a/src/vendor.rs
+++ b/src/vendor.rs
@@ -21,6 +21,7 @@ use crate::buckify::relative_path;
 use crate::cargo;
 use crate::config::Config;
 use crate::config::VendorConfig;
+use crate::config::VendorSourceConfig;
 use crate::remap::RemapConfig;
 use crate::Args;
 use crate::Paths;
@@ -68,8 +69,8 @@ pub(crate) fn cargo_vendor(
         assert!(is_vendored(paths)?);
     }
 
-    if let Some(vendor_config) = &config.vendor {
-        filter_checksum_files(&paths.third_party_dir, vendordir, vendor_config)?;
+    if let VendorConfig::Source(source_config) = &config.vendor {
+        filter_checksum_files(&paths.third_party_dir, vendordir, source_config)?;
     }
 
     if audit_sec {
@@ -115,7 +116,7 @@ pub(crate) fn is_vendored(paths: &Paths) -> anyhow::Result<bool> {
 fn filter_checksum_files(
     third_party_dir: &Path,
     vendordir: &Path,
-    config: &VendorConfig,
+    config: &VendorSourceConfig,
 ) -> anyhow::Result<()> {
     if config.checksum_exclude.is_empty() && config.gitignore_checksum_exclude.is_empty() {
         return Ok(());

--- a/src/vendor.rs
+++ b/src/vendor.rs
@@ -43,7 +43,7 @@ pub(crate) fn cargo_vendor(
     let vendordir = Path::new("vendor"); // relative to third_party_dir
 
     match &config.vendor {
-        VendorConfig::Compressed => {
+        VendorConfig::LocalRegistry => {
             let mut cmdline = vec![
                 "local-registry",
                 "-s",
@@ -143,13 +143,13 @@ pub(crate) fn is_vendored(config: &Config, paths: &Paths) -> anyhow::Result<bool
         .context(format!("Failed to parse {}", cargo_config_path.display()))?;
 
     let source_name = match config.vendor {
-        VendorConfig::Compressed => "local-registry",
+        VendorConfig::LocalRegistry => "local-registry",
         VendorConfig::Source(_) => "vendored-sources",
         _ => return Ok(false),
     };
     match remap_config.sources.get(source_name) {
         Some(source) => match config.vendor {
-            VendorConfig::Compressed => Ok(source.local_registry.is_some()),
+            VendorConfig::LocalRegistry => Ok(source.local_registry.is_some()),
             VendorConfig::Source(_) => Ok(source.directory.is_some()),
             VendorConfig::Off => Ok(false),
         },

--- a/src/vendor.rs
+++ b/src/vendor.rs
@@ -54,14 +54,23 @@ pub(crate) fn cargo_vendor(
                 cmdline.push("--no-delete");
             }
             log::info!("Running cargo {:?}", cmdline);
-            let mut cargoconfig = cargo::run_cargo(
+            let _ = cargo::run_cargo(
                 config,
                 Some(&paths.cargo_home),
                 &paths.third_party_dir,
                 args,
                 &cmdline,
             )?;
-            cargoconfig.splice(0..0, b"# ".iter().copied());
+            let cargoconfig = format!(
+                r#"[source.crates-io]
+registry = 'sparse+https://index.crates.io/'
+replace-with = 'local-registry'
+
+[source.local-registry]
+local-registry = {vendordir:?}
+"#
+            );
+            // cargoconfig.splice(0..0, b"# ".iter().copied());
             fs::write(paths.cargo_home.join("config.toml"), &cargoconfig)?;
             // if !cargoconfig.is_empty() {
             //     assert!(is_vendored(paths)?);

--- a/src/vendor.rs
+++ b/src/vendor.rs
@@ -49,6 +49,7 @@ pub(crate) fn cargo_vendor(
                 "-s",
                 paths.lockfile_path.to_str().unwrap(),
                 vendordir.to_str().unwrap(),
+                "--git",
             ];
             if no_delete {
                 cmdline.push("--no-delete");


### PR DESCRIPTION
The problem is a goldilocks one.

1. `vendor = false` is quick & easy to manage deps & buckify, but pretty bad day to day. 
    - Doesn't work offline as buck2 issues HEAD requests constantly
    - Terrible DX annoyance with "too many open files" errors due to buck trying to download 1000 crates at once. The standard start to your day looks like "run buck2 build about 15 times until by random chance the scheduler manages to get past those errors"
    - Those crates get downloaded again, and again, and again
    - `reindeer buckify` takes 2 seconds or so. Pretty convenient.

2. `[vendor] ...` is slow to manage deps & buckify.
    - Neat for small projects
    - Also probably neat for Meta with y'all's funky  EdenFS etc.
    - But middle ground is bad
        - Middle = `vendor` directory of 1000 crates, 1.2 GB, 50k source files. Mostly from dupes of the windows crates which can't be pinned to one single version etc.
        - `reindeer vendor` takes 35 seconds
        - `reindeer buckify` takes 20 seconds
        - `git status` takes 150ms
        -  The vendor folder wrecks git performance simply by its existence.
    - Build experience is perfect, works offline, etc.

I think we need a solution for the middle ground:

- `vendor = "local-registry"`, using https://github.com/dhovart/cargo-local-registry
- `reindeer vendor` ultimately just writes a bunch of .crate files into vendor/, which are just gzipped tarballs
- .crate files stored in git, but using git-lfs if you like. Suddenly `windows-0.48.0.crate` is just a blob. Your diffs are much simpler when you modify deps. Etc.
- Some buck2 rule to extract them. (There is no prelude rule that can do this with `strip_prefix` and `sub_targets` support, but prelude's `extract_archive` could probably have that added.)

Outcomes:
- Offline works (~~although doesn't handle cargo `package = { git = "..." }` deps yet~~).
- `reindeer vendor` and `reindeer buckify` both take 2 seconds
- `git status` takes 20ms
- Buck builds are a compromise, but a pretty great one. It still has to extract the tarballs when you want to build things. But at least buck won't ever actually extract `windows-0.48.0.crate` on linux, and you only pay for what you build.
- The DX annoyance factor during builds is back to zero. No more too many open files errors.
- DX annoyance when updating deps is acceptable.

Problems:
- Relies on https://github.com/dhovart/cargo-local-registry being installed. Note however this is a single-file binary. I think if you rewrote it without the dependency on the `cargo` crate it would be maybe a 2-file crate. And we could use it as a library.
- I think storing the local registry's `index` folder (nested `ab/ ac/ ah/ ...` folders) might be a little bit annoying if you're making concurrent edits on different branches. But you can always regenerate.