### PR TITLE
Fix typo in buildscript fixups comment

### DIFF
--- a/src/fixups/buildscript.rs
+++ b/src/fixups/buildscript.rs
@@ -54,7 +54,7 @@ impl Deref for BuildscriptFixups {
 pub enum BuildscriptFixup {
     /// Unresolved build script (string with helpful message)
     Unresolved(String),
-    /// Run the buildscript and extact command line args. Linker -l/-L args ignored so in
+    /// Run the buildscript and extract command line args. Linker -l/-L args ignored so in
     /// practice this is just --cfg options.
     RustcFlags(RustcFlags),
     /// Generated sources - give list of generated paths which are mapped into target sources


### PR DESCRIPTION
My understanding is that with this flag reindeer will run the build script, grab it's stdout, assume that the stdout are rustc flags, and use those flags to build the crate. So perhaps this meant to say "Run the buildscript and _extract_ command line args"?