### PR TITLE
github: unbreak release workflow by using macos-13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
             cross: true
           - os: 'macos-14'
             triple: 'aarch64-apple-darwin'
-          - os: 'macos-12'
+          - os: 'macos-13'
             triple: 'x86_64-apple-darwin'
           - os: 'windows-2022'
             triple: 'x86_64-pc-windows-msvc'


### PR DESCRIPTION
macos-12 is deprecated, and doesn't seem to be working anymore. macos-13 can still be used to produce x86_64 binaries for now.