### PR TITLE
Fix missing build script filegroup for local and git-patched crates

### DIFF
--- a/src/fixups/config.rs
+++ b/src/fixups/config.rs
@@ -237,7 +237,7 @@ impl FixupConfig {
 /// `cargo_env` selection.
 ///
 /// Deserializes from `true`, `false` or `["CARGO_MANIFEST_DIR", ...]`.
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub enum CargoEnvs {
     All,
     #[default]


### PR DESCRIPTION
Summary:
This PR (together with facebook/buck2#915) fixes an issue where build scripts in local crates and git-patched dependencies cannot access their source files.

Problem:
For a build script to access its crate's source files, it needs a filegroup target referencing those files. While Reindeer automatically creates such targets for crates.io dependencies using the `http_archive` rule, it doesn't do so for:

1. Local crates (including workspace members)
2. Git-patched dependencies
3. Vendored crates

The current implementation only handles case 3 (vendoring), leaving the first two cases unhandled.

Solution:
This PR modifies the `cargo_env` handling to ensure that -build-scripts-build targets for local and git-patched crates always receive these 3 necessary environment variables:

- `CARGO_MANIFEST_DIR`
- `CARGO_PKG_NAME`
- `CARGO_PKG_VERSION`

These variables allow Buck2 rules to create additional filegroups named `"{CARGO_PKG_NAME}-{CARGO_PKG_VERSION}.crate"` with files under the `{CARGO_MANIFEST_DIR}` path, which enable build script executables to access their source files.

Testing:
A [demonstration repository](https://github.com/yxdai-nju/reindeer-local-buildrs-issue-demo) verifies this fix works for both local crates and git-patched dependencies.