### PR TITLE
Use workspace_members instead of workspace_default_members

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -248,7 +248,7 @@ pub struct Metadata {
     #[serde(deserialize_with = "deserialize_default_from_null")]
     pub packages: BTreeSet<Manifest>,
     pub version: u32,
-    pub workspace_default_members: Vec<PkgId>,
+    pub workspace_members: Vec<PkgId>,
     /// Resolved dependency graph
     pub resolve: Resolve,
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -81,7 +81,7 @@ impl<'meta> Index<'meta> {
         };
 
         let workspace_members: Vec<_> = metadata
-            .workspace_default_members
+            .workspace_members
             .iter()
             .filter_map(|pkgid| pkgid_to_pkg.get(pkgid).copied())
             .collect();


### PR DESCRIPTION
This was an oversight in #54. `include_workspace_members = false` should get 
rid of all workspace members, not just the default ones. Default workspace 
members are just a Cargo convenience for what `cargo test` should test, etc., 
and should have no bearing on this.
