### PR TITLE
Support Buck2's new buildscript_run environment variable handling (draft)

### DIFF
--- a/src/buck.rs
+++ b/src/buck.rs
@@ -588,7 +588,7 @@ impl Serialize for PlatformRustCommon {
         if !env.is_empty() {
             map.serialize_entry("env", env)?;
         }
-        if !env.is_empty() {
+        if !env_flags.is_empty() {
             map.serialize_entry("env_flags", env_flags)?;
         }
         if !features.is_empty() {

--- a/src/buck.rs
+++ b/src/buck.rs
@@ -557,6 +557,7 @@ pub struct PlatformRustCommon {
     pub deps: Selectable<UniverseName, BTreeSet<RuleRef>>,
     pub named_deps: Selectable<UniverseName, BTreeMap<String, RuleRef>>,
     pub env: Selectable<UniverseName, BTreeMap<String, StringOrPath>>,
+    pub env_flags: BTreeSet<String>,
 
     // This isn't really "common" (Binaries only), but does need to be platform
     pub link_style: Option<String>,
@@ -575,6 +576,7 @@ impl Serialize for PlatformRustCommon {
             deps,
             named_deps,
             env,
+            env_flags,
             link_style,
             linker_flags,
             preferred_linkage,
@@ -585,6 +587,9 @@ impl Serialize for PlatformRustCommon {
         }
         if !env.is_empty() {
             map.serialize_entry("env", env)?;
+        }
+        if !env.is_empty() {
+            map.serialize_entry("env_flags", env_flags)?;
         }
         if !features.is_empty() {
             map.serialize_entry("features", features)?;
@@ -711,6 +716,7 @@ impl Serialize for RustLibrary {
                             deps,
                             named_deps,
                             env,
+                            env_flags,
                             link_style,
                             linker_flags,
                             preferred_linkage,
@@ -738,6 +744,9 @@ impl Serialize for RustLibrary {
         map.serialize_entry("edition", edition)?;
         if !env.is_empty() {
             map.serialize_entry("env", env)?;
+        }
+        if !env_flags.is_empty() {
+            map.serialize_entry("env_flags", env_flags)?;
         }
         if !features.is_empty() {
             map.serialize_entry("features", features)?;
@@ -812,6 +821,7 @@ impl Serialize for RustBinary {
                             deps,
                             named_deps,
                             env,
+                            env_flags,
                             link_style,
                             linker_flags,
                             preferred_linkage,
@@ -832,6 +842,9 @@ impl Serialize for RustBinary {
         map.serialize_entry("edition", edition)?;
         if !env.is_empty() {
             map.serialize_entry("env", env)?;
+        }
+        if !env_flags.is_empty() {
+            map.serialize_entry("env_flags", env_flags)?;
         }
         if !features.is_empty() {
             map.serialize_entry("features", features)?;

--- a/src/buckify.rs
+++ b/src/buckify.rs
@@ -657,6 +657,22 @@ fn generate_target_rules<'scope>(
     )
     .context("env")?;
 
+    unzip_platform(
+        config,
+        &mut base,
+        &mut perplat,
+        |rule, flags| {
+            log::debug!(
+                "pkg {} target {}: adding env_flags for rustc_flags/gen_srcs",
+                pkg,
+                tgt.name,
+            );
+            rule.env_flags.extend(flags);
+        },
+        fixups.compute_env_flags(),
+    )
+    .context("env_flags")?;
+
     // Compute set of dependencies any rule we generate here will need. They will only
     // be emitted if we actually emit some rules below.
     let mut dep_pkgs = Vec::new();


### PR DESCRIPTION
### Summary
This PR allows Reindeer to work with the new build script environment variable feature introduced in Buck2.

Relates to facebook/buck2#919.

### Changes
- Added support for the new `[env_flags]` sub-target on `buildscript_run`

Reindeer can now generate rules that utilize environment variable outputs from build scripts via `env_flags`.

For example, for mime_guess 2.0.5, Reindeer can now generate:

```starlark
# BUCK
cargo.rust_library(
    name = "mime_guess-2.0.5",
    crate_root = "mime_guess-2.0.5.crate/src/lib.rs",
    env_flags = ["@$(location :mime_guess-2.0.5-build-script-run[env_flags])"],
    rustc_flags = ["@$(location :mime_guess-2.0.5-build-script-run[rustc_flags])"],
    # ...
)
```

This is generated with a simple "rustc_flags" fixup:

```toml
# fixups/mime_guess/fixups.toml
[[buildscript]]
[buildscript.rustc_flags]
```

This eliminates the need for manual environment variable fixups for crates that use `cargo:rustc-env`.