### PR TITLE
Version requirements in platform predicates

### DIFF
--- a/src/buck.rs
+++ b/src/buck.rs
@@ -99,13 +99,17 @@ impl RuleRef {
 
     /// Return true if one of the platform_configs applies to this rule. Always returns
     /// true if this dep has no platform constraint.
-    pub fn filter(&self, platform_config: &PlatformConfig) -> Result<bool, PredicateParseError> {
+    pub fn filter(
+        &self,
+        platform_config: &PlatformConfig,
+        version: &semver::Version,
+    ) -> Result<bool, PredicateParseError> {
         let res = match &self.platform {
             None => true,
             Some(cfg) => {
                 let cfg = PlatformPredicate::parse(cfg)?;
 
-                cfg.eval(platform_config)
+                cfg.eval(platform_config, Some(version))
             }
         };
         Ok(res)

--- a/src/buckify.rs
+++ b/src/buckify.rs
@@ -688,10 +688,10 @@ fn generate_target_rules<'scope>(
                     dep,
                     name,
                     platform,
-                    dep.filter(platform)
+                    dep.filter(platform, &pkg.version)
                 );
 
-                if dep.filter(platform)? {
+                if dep.filter(platform, &pkg.version)? {
                     let dep = dep.clone();
 
                     let recipient = if is_default {


### PR DESCRIPTION
Builds, not yet tested. I'm not sure if ignoring version requirements for `platform_names_for_expr` is correct, or whether I'm passing the right version in calls to `filter`.