### PR TITLE
Pass buildscript env to build-script-run rule

### DIFF
--- a/src/buck.rs
+++ b/src/buck.rs
@@ -174,6 +174,12 @@ pub enum StringOrPath {
     Path(BuckPath),
 }
 
+impl From<String> for StringOrPath {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize)]
 #[serde(untagged)]
 pub enum SubtargetOrPath {
@@ -875,7 +881,7 @@ pub struct BuildscriptGenrule {
     pub package_name: String,
     pub version: Version,
     pub features: Selectable<UniverseName, BTreeSet<String>>,
-    pub env: BTreeMap<String, String>,
+    pub env: BTreeMap<String, StringOrPath>,
     pub local_manifest_dir: Option<BuckPath>,
     pub manifest_dir: Option<Subtarget>,
 }

--- a/src/fixups.rs
+++ b/src/fixups.rs
@@ -323,7 +323,7 @@ impl<'meta> Fixups<'meta> {
             package_name: self.package.name.clone(),
             version: self.package.version.clone(),
             features: buck::Selectable::Value(features.clone()),
-            env: BTreeMap::new(),
+            env: buildscript.common.base.env.unwrap_ref().clone(),
             local_manifest_dir: local_manifest_dir.clone(),
             manifest_dir: manifest_dir.clone(),
         };
@@ -361,7 +361,9 @@ impl<'meta> Fixups<'meta> {
 
                     // Emit rule to get its stdout and filter it into args
                     let buildscript_run = buildscript_run.get_or_insert_with(default_genrule);
-                    buildscript_run.env.extend(env.clone());
+                    buildscript_run
+                        .env
+                        .extend(env.iter().map(|(k, v)| (k.clone(), v.clone().into())));
                 }
 
                 // Generated source files - given a list, set up rules to extract them from
@@ -372,7 +374,9 @@ impl<'meta> Fixups<'meta> {
 
                     // Emit rules to extract generated sources
                     let buildscript_run = buildscript_run.get_or_insert_with(default_genrule);
-                    buildscript_run.env.extend(env.clone());
+                    buildscript_run
+                        .env
+                        .extend(env.iter().map(|(k, v)| (k.clone(), v.clone().into())))
                 }
 
                 // Emit a C++ library build rule (elsewhere - add a dependency to it)


### PR DESCRIPTION
This exactly duplicates the environment passed at build script compile time, which I *think* is correct? Fixes https://github.com/facebookincubator/reindeer/issues/68.