### PR TITLE
[fixups] allow `preferred_linkage` in prebuilt_cxx_library fixups

### DIFF
--- a/src/buck.rs
+++ b/src/buck.rs
@@ -907,6 +907,7 @@ impl<'a> Serialize for PreprocessorFlags<'a> {
 pub struct PrebuiltCxxLibrary {
     pub common: Common,
     pub static_lib: SubtargetOrPath,
+    pub preferred_linkage: Option<String>,
 }
 
 impl Serialize for PrebuiltCxxLibrary {
@@ -921,6 +922,7 @@ impl Serialize for PrebuiltCxxLibrary {
                     target_compatible_with,
                 },
             static_lib,
+            preferred_linkage,
         } = self;
         let mut map = ser.serialize_map(None)?;
         map.serialize_entry("name", name)?;
@@ -935,6 +937,9 @@ impl Serialize for PrebuiltCxxLibrary {
             map.serialize_entry("target_compatible_with", target_compatible_with)?;
         }
         map.serialize_entry("visibility", visibility)?;
+        if let Some(preferred_linkage) = preferred_linkage {
+            map.serialize_entry("preferred_linkage", preferred_linkage)?;
+        }
         map.end()
     }
 }

--- a/src/fixups.rs
+++ b/src/fixups.rs
@@ -469,6 +469,7 @@ impl<'meta> Fixups<'meta> {
             public,
             compatible_with,
             target_compatible_with,
+            preferred_linkage,
             ..
         } in prebuilt_cxx_library
         {
@@ -505,6 +506,7 @@ impl<'meta> Fixups<'meta> {
                         target_compatible_with: target_compatible_with.clone(),
                     },
                     static_lib: self.subtarget_or_path(&static_lib)?,
+                    preferred_linkage: preferred_linkage.clone(),
                 };
                 res.push(Rule::PrebuiltCxxLibrary(rule));
             }

--- a/src/fixups/buildscript.rs
+++ b/src/fixups/buildscript.rs
@@ -133,6 +133,8 @@ pub struct PrebuiltCxxLibraryFixup {
     pub compatible_with: Vec<RuleRef>,
     #[serde(default)]
     pub target_compatible_with: Vec<RuleRef>,
+    #[serde(default)]
+    pub preferred_linkage: Option<String>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
sometimes (e.g. when compiling wasm and `wit-bindgen-rt`) you need to be able to specify that a particular prebuilt library should be used as a static library, and not converted to a shared library.  

the best way to force this seems to be `preferred_linkage` on the generated `prebuilt_cxx_library` itself.