### PR TITLE
drop trailing slash in `mapped_manifest_dir` for git sources

### DIFF
--- a/src/buckify.rs
+++ b/src/buckify.rs
@@ -459,7 +459,12 @@ fn generate_target_rules<'scope>(
                 target: Name(format!("{}.git", short_name)),
                 relative: BuckPath(path_within_repo.clone()),
             }));
-            PathBuf::from(short_name).join(path_within_repo)
+            let mut res = PathBuf::from(short_name);
+            if path_within_repo.components().next().is_some() {
+                // only do this if we have an actual path to avoid the trailing slash
+                res.push(path_within_repo)
+            }
+            res
         } else {
             PathBuf::from(format!("{}-{}.crate", pkg.name, pkg.version))
         };


### PR DESCRIPTION
in git sources, when the repo root is the same as the manifest dir, currently reindeer with attempt to join the repo name with an empty path (the manifest sub-path), which produces a path with a trailing slash, due to how `Path::join` works.

This path is later used to create the key in a buck2 file-to-source map-dict, which fails, since buck2 does not want trailing slashes in the keys for those maps.

this detects if the manifest sub-path would be empty, and skips joining it.