### PR TITLE
Validate extra_srcs and omit_srcs even if not vendoring

### DIFF
--- a/src/fixups.rs
+++ b/src/fixups.rs
@@ -1481,6 +1481,20 @@ impl<'meta> Fixups<'meta> {
         Ok(extra_srcs)
     }
 
+    pub fn validate_srcs_fixups(&self, target: &ManifestTarget, platform_name: &PlatformName) {
+        let buildscript = target.crate_bin() && target.kind_custom_build();
+
+        for fixup in self.configs(platform_name) {
+            let extra_srcs = if buildscript {
+                &fixup.buildscript.build.extra_srcs
+            } else {
+                &fixup.extra_srcs
+            };
+            for _ in Globs::new(extra_srcs, NO_EXCLUDE).walk(self.manifest_dir) {}
+            for _ in Globs::new(&fixup.omit_srcs, NO_EXCLUDE).walk(self.manifest_dir) {}
+        }
+    }
+
     pub fn compute_mapped_srcs(
         &self,
         mapped_manifest_dir: &Path,


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebookincubator/reindeer/issues/87.

Although `extra_srcs` and `omit_srcs` fixups do not affect the generated Buck target for a crate that is neither vendored nor a local path dependency, we will still evaluate globs in the fixup against the contents of the manifest directory so that unmatched globs are accurately reported.

Differential Revision: D88338079


