### PR TITLE
Update third-party Rust crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2595,9 +2595,9 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.3",
  "libc",
@@ -3503,9 +3503,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/facebookincubator/reindeer"
 license = "MIT"
 
 [dependencies]
-anyhow = "1.0.98"
+anyhow = "1.0.100"
 cached = { version = "0.55.1", features = ["async", "disk_store"] }
 cargo = "0.92"
 cargo_toml = "0.22.1"
@@ -25,7 +25,7 @@ ignore = "0.4"
 indexmap = { version = "2.13.0", features = ["arbitrary", "rayon", "serde"] }
 indoc = "2.0.2"
 itertools = "0.14.0"
-log = { version = "0.4.27", features = ["kv_unstable", "kv_unstable_std"] }
+log = { version = "0.4.28", features = ["kv_unstable", "kv_unstable_std"] }
 measure_time = "0.9"
 monostate = "1"
 nom = "8"
@@ -33,7 +33,7 @@ nom-language = "0.1"
 proc-macro2 = { version = "1.0.106", features = ["span-locations"] }
 semver = { version = "1.0.26", features = ["serde"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
+serde_json = { version = "1.0.145", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 serde_starlark = "0.1.19"
 serde_with = { version = "3", features = ["hex", "json"] }
 spdx = "0.13"


### PR DESCRIPTION
Summary:
Bump versions and add new Rust third-party crate dependencies needed by ripgrep.

**Version bumps:**
- `anyhow` 1.0.98 → 1.0.100
- `cfg-if` 1.0 → 1.0.4
- `log` 0.4.27 → 0.4.28
- `memchr` 2.7.5 → 2.7.6
- `serde_json` 1.0.140 → 1.0.145

**New crate dependencies added to Cargo.toml:**
- `arbitrary` 1.4.2
- `crossbeam-deque` 0.8.6
- `crossbeam-epoch` 0.9.18
- `crossbeam-utils` 0.8.21
- `derive_arbitrary` 1.4.2
- `find-msvc-tools` 0.1.5
- `jemalloc-sys` 0.6.1 (package: tikv-jemalloc-sys)
- `jobserver` 0.1.34
- `pcre2-sys` 0.2.10
- `ryu` 1.0.23
- `same-file` 1.0.6
- `serde_core` 1.0.228
- `wasip2` 1.0.1+wasi-0.2.4
- `winapi-util` 0.1.11
- `windows-link` 0.1.1
- `wit-bindgen` 0.46.0

Note for OSS projects: if you are reading this from GitHub pull requests, then it does not mean all of these crates will be added or updates, but only some subset that is used in the project.

Differential Revision: D93193734


