### PR TITLE
Fix: Silent non-deterministic EMFILE related failure on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3608,6 +3608,7 @@ dependencies = [
  "nom 8.0.0",
  "nom-language",
  "proc-macro2",
+ "rlimit",
  "semver",
  "serde",
  "serde_json",
@@ -3634,6 +3635,15 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "rlimit"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f35ee2729c56bb610f6dba436bf78135f728b7373bdffae2ec815b2d3eb98cc3"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ monostate = "1"
 nom = "8"
 nom-language = "0.1"
 proc-macro2 = { version = "1.0.106", features = ["span-locations"] }
+rlimit = "0.11"
 semver = { version = "1.0.28", features = ["serde"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }

--- a/src/buckify.rs
+++ b/src/buckify.rs
@@ -691,10 +691,10 @@ fn generate_target_rules<'a>(
         // individual contained files.
         //
         // But we validate globs anyway.
-        for _ in license_globs.walk(manifest_dir) {}
+        license_globs.walk(manifest_dir)?;
     } else {
         let rel_manifest = relative_path(&paths.third_party_dir, manifest_dir);
-        for path in license_globs.walk(manifest_dir) {
+        for path in license_globs.walk(manifest_dir)? {
             licenses.insert(BuckPath(rel_manifest.join(path)));
         }
         if let Some(license_file) = &pkg.license_file {
@@ -733,7 +733,7 @@ fn generate_target_rules<'a>(
             let dir_containing_src = tgt.src_path.parent().unwrap();
             let pattern = relative_path(manifest_dir, dir_containing_src).join("**/*.rs");
             let glob = Globs::new(GlobSetKind::from_iter([pattern]).unwrap(), NO_EXCLUDE);
-            srcs.extend(glob.walk(manifest_dir));
+            srcs.extend(glob.walk(manifest_dir)?);
         }
 
         evaluate_for_platforms(
@@ -749,7 +749,7 @@ fn generate_target_rules<'a>(
             // when we are not producing a srcs list, still evaluate globs in
             // the fixup against the contents of the manifest directory so that
             // unmatched globs are accurately reported.
-            fixups.validate_srcs_fixups(tgt, platform);
+            fixups.validate_srcs_fixups(tgt, platform)?;
         }
         if let VendorConfig::LocalRegistry = config.vendor {
             let extract_archive_target = format!(":{}-{}.crate", pkg.name, pkg.version);
@@ -786,7 +786,7 @@ fn generate_target_rules<'a>(
     // be emitted if we actually emit some rules below.
     let mut platform_deps = Vec::new();
     for &platform_name in &compatible_platforms {
-        let deps = fixups.compute_deps(platform_name, index, tgt, collision_info);
+        let deps = fixups.compute_deps(platform_name, index, tgt, collision_info)?;
         platform_deps.push((platform_name, deps));
     }
 
@@ -1321,20 +1321,20 @@ fn generate_target_rules<'a>(
             if config.buck.split {
                 // e.g. ["src/lib.rs"]
                 FilegroupSources::Set(BTreeSet::from_iter(
-                    export_globs.walk(manifest_dir).map(BuckPath),
+                    export_globs.walk(manifest_dir)?.into_iter().map(BuckPath),
                 ))
             } else {
                 // e.g. {"src/lib.rs": "vendor/foo-1.0.0/src/lib.rs"}
-                FilegroupSources::Map(BTreeMap::from_iter(export_globs.walk(manifest_dir).map(
-                    |path| {
+                FilegroupSources::Map(BTreeMap::from_iter(
+                    export_globs.walk(manifest_dir)?.into_iter().map(|path| {
                         let source = mapped_manifest_dir.join(&path);
                         (BuckPath(path), SubtargetOrPath::Path(BuckPath(source)))
-                    },
-                )))
+                    }),
+                ))
             }
         } else {
             // Validate the globs anyway
-            for _ in export_globs.walk(manifest_dir) {}
+            export_globs.walk(manifest_dir)?;
 
             if let VendorConfig::LocalRegistry = config.vendor {
                 // e.g. {":foo-1.0.0.git": "foo-1.0.0"}

--- a/src/fixups.rs
+++ b/src/fixups.rs
@@ -519,18 +519,21 @@ impl<'meta> Fixups<'meta> {
                         },
                     },
                     srcs: Globs::new(srcs, exclude)
-                        .walk(self.manifest_dir)
+                        .walk(self.manifest_dir)?
+                        .into_iter()
                         .map(|path| SubtargetOrPath::Path(BuckPath(path)))
                         .collect(),
                     headers: Globs::new(headers, exclude)
-                        .walk(self.manifest_dir)
+                        .walk(self.manifest_dir)?
+                        .into_iter()
                         .map(|path| SubtargetOrPath::Path(BuckPath(path)))
                         .collect(),
                     exported_headers: match exported_headers {
                         ExportedHeaders::Set(exported_headers) => {
                             let exported_header_globs = Globs::new(exported_headers, exclude);
                             let exported_headers = exported_header_globs
-                                .walk(self.manifest_dir)
+                                .walk(self.manifest_dir)?
+                                .into_iter()
                                 .map(|path| SubtargetOrPath::Path(BuckPath(path)))
                                 .collect();
                             SetOrMap::Set(exported_headers)
@@ -609,7 +612,8 @@ impl<'meta> Fixups<'meta> {
                     },
                     // Just collect the sources, excluding things in the exclude list
                     srcs: Globs::new(srcs, exclude)
-                        .walk(self.manifest_dir)
+                        .walk(self.manifest_dir)?
+                        .into_iter()
                         .map(|path| self.subtarget_or_path(&path))
                         .collect::<anyhow::Result<_>>()?,
                     // Collect the nominated headers, plus everything in the fixup include
@@ -617,7 +621,7 @@ impl<'meta> Fixups<'meta> {
                     headers: {
                         let globs = Globs::new(headers, exclude);
                         let mut headers = BTreeSet::new();
-                        for path in globs.walk(self.manifest_dir) {
+                        for path in globs.walk(self.manifest_dir)? {
                             headers.insert(self.subtarget_or_path(&path)?);
                         }
 
@@ -627,7 +631,7 @@ impl<'meta> Fixups<'meta> {
                         );
                         for fixup_include_path in fixup_include_paths {
                             for path in
-                                globs.walk(self.fixup_config.fixup_dir.join(fixup_include_path))
+                                globs.walk(self.fixup_config.fixup_dir.join(fixup_include_path))?
                             {
                                 headers.insert(SubtargetOrPath::Path(BuckPath(
                                     rel_fixup.join(fixup_include_path).join(path),
@@ -641,7 +645,8 @@ impl<'meta> Fixups<'meta> {
                         ExportedHeaders::Set(exported_headers) => {
                             let exported_header_globs = Globs::new(exported_headers, exclude);
                             let exported_headers = exported_header_globs
-                                .walk(self.manifest_dir)
+                                .walk(self.manifest_dir)?
+                                .into_iter()
                                 .map(|path| self.subtarget_or_path(&path))
                                 .collect::<anyhow::Result<_>>()?;
                             SetOrMap::Set(exported_headers)
@@ -701,7 +706,7 @@ impl<'meta> Fixups<'meta> {
         } in prebuilt_cxx_library
         {
             let static_lib_globs = Globs::new(static_libs, NO_EXCLUDE);
-            for static_lib in static_lib_globs.walk(self.manifest_dir) {
+            for static_lib in static_lib_globs.walk(self.manifest_dir)? {
                 let static_lib_file_name = static_lib.file_name().unwrap().to_string_lossy();
                 let prebuilt_cxx_library_target = if self.config.buck.split {
                     let target_name = Name(format!("{}-{}", name, static_lib_file_name));
@@ -1107,7 +1112,9 @@ impl<'meta> Fixups<'meta> {
         index: &'meta Index<'meta>,
         target: &'meta ManifestTarget,
         collision_info: &CollisionInfo,
-    ) -> HashMap<(RuleRef, Option<&'meta str>, &'meta NodeDepKind), Option<&'meta Manifest>> {
+    ) -> anyhow::Result<
+        HashMap<(RuleRef, Option<&'meta str>, &'meta NodeDepKind), Option<&'meta Manifest>>,
+    > {
         let mut ret = HashMap::new();
 
         // Get dependencies according to Cargo.
@@ -1182,7 +1189,7 @@ impl<'meta> Fixups<'meta> {
                     continue;
                 }
                 let static_lib_globs = Globs::new(static_libs, NO_EXCLUDE);
-                for static_lib in static_lib_globs.walk(self.manifest_dir) {
+                for static_lib in static_lib_globs.walk(self.manifest_dir)? {
                     ret.insert(
                         (
                             RuleRef::new(if self.config.buck.split {
@@ -1268,7 +1275,7 @@ impl<'meta> Fixups<'meta> {
             );
         }
 
-        ret
+        Ok(ret)
     }
 
     pub fn omit_dep(&self, platform_name: &PlatformName, dep: &str) -> bool {
@@ -1531,7 +1538,7 @@ impl<'meta> Fixups<'meta> {
                 }
             } else {
                 let globs = Globs::new(GlobSetKind::from_iter([rest_of_glob])?, NO_EXCLUDE);
-                for path in globs.walk(&dir_containing_extra_srcs) {
+                for path in globs.walk(&dir_containing_extra_srcs)? {
                     insert(&dir_containing_extra_srcs.join(path));
                 }
             }
@@ -1540,7 +1547,11 @@ impl<'meta> Fixups<'meta> {
         Ok(extra_srcs)
     }
 
-    pub fn validate_srcs_fixups(&self, target: &ManifestTarget, platform_name: &PlatformName) {
+    pub fn validate_srcs_fixups(
+        &self,
+        target: &ManifestTarget,
+        platform_name: &PlatformName,
+    ) -> anyhow::Result<()> {
         let buildscript = target.crate_bin() && target.kind_custom_build();
 
         for fixup in self.configs(platform_name) {
@@ -1549,9 +1560,10 @@ impl<'meta> Fixups<'meta> {
             } else {
                 &fixup.extra_srcs
             };
-            for _ in Globs::new(extra_srcs, NO_EXCLUDE).walk(self.manifest_dir) {}
-            for _ in Globs::new(&fixup.omit_srcs, NO_EXCLUDE).walk(self.manifest_dir) {}
+            Globs::new(extra_srcs, NO_EXCLUDE).walk(self.manifest_dir)?;
+            Globs::new(&fixup.omit_srcs, NO_EXCLUDE).walk(self.manifest_dir)?;
         }
+        Ok(())
     }
 
     pub fn compute_mapped_srcs(

--- a/src/glob.rs
+++ b/src/glob.rs
@@ -13,6 +13,7 @@ use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 
+use anyhow::Context;
 use globset::GlobBuilder;
 use globset::GlobMatcher;
 use globset::GlobSet;
@@ -174,25 +175,27 @@ impl<'a> Globs<'a> {
     }
 
     /// Returns relative paths (relative to `dir`) of all the matching files.
-    pub fn walk(&self, dir: impl AsRef<Path>) -> impl Iterator<Item = PathBuf> {
+    ///
+    /// Any error from `WalkDir` (a missing directory, EMFILE, permission
+    /// failures, etc.) is surfaced. We may need to add some deliberate
+    /// error-swallowing for actually-irrelevant errors in the future.
+    pub fn walk(&self, dir: impl AsRef<Path>) -> anyhow::Result<Vec<PathBuf>> {
         let dir = dir.as_ref();
-        WalkDir::new(dir)
-            .into_iter()
-            .filter_map(Result::ok)
-            .filter(|entry| !entry.file_type().is_dir())
-            .filter_map(move |entry| {
-                let path = entry
-                    .path()
-                    .strip_prefix(dir)
-                    .expect("walkdir produced paths not inside intended dir");
-                if self.globset.is_match(path) && !self.exceptset.is_match(path) {
-                    Some(path.to_owned())
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>()
-            .into_iter()
+        let mut result = Vec::new();
+        for entry in WalkDir::new(dir) {
+            let entry = entry.with_context(|| format!("failed to walk {}", dir.display()))?;
+            if entry.file_type().is_dir() {
+                continue;
+            }
+            let path = entry
+                .path()
+                .strip_prefix(dir)
+                .expect("walkdir produced paths not inside intended dir");
+            if self.globset.is_match(path) && !self.exceptset.is_match(path) {
+                result.push(path.to_owned());
+            }
+        }
+        Ok(result)
     }
 }
 
@@ -237,5 +240,23 @@ impl<'a> From<&'a TrackedGlob> for GlobSetKind<'a> {
 impl<'a> From<&'a TrackedGlobSet> for GlobSetKind<'a> {
     fn from(globset: &'a TrackedGlobSet) -> Self {
         GlobSetKind::TrackedSet(globset)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn walk_propagates_missing_directory_error() {
+        let globs = Globs::new(GlobSetKind::from_iter(["**/*.rs"]).unwrap(), NO_EXCLUDE);
+        let err = globs
+            .walk("/nonexistent/path/that/should/not/exist")
+            .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("/nonexistent/path/that/should/not/exist"),
+            "expected error to mention the walked dir, got: {msg}",
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Library surface for integration tests under `tests/`. Reindeer is primarily
+//! a binary; only modules that integration tests need are re-exposed here.
+//! The binary in `src/main.rs` keeps its own `mod` declarations and does not
+//! depend on this lib.
+
+pub mod glob;
+pub mod unused;

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ mod lockfile;
 mod path;
 mod platform;
 mod remap;
+mod rlimit;
 mod srcfiles;
 mod subtarget;
 mod tp_metadata;
@@ -280,6 +281,8 @@ fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"))
         .format_timestamp(None)
         .init();
+
+    rlimit::raise_nofile_limit();
 
     if let Err(err) = try_main() {
         log::error!("{:?}", err);

--- a/src/rlimit.rs
+++ b/src/rlimit.rs
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Raise `RLIMIT_NOFILE` so parallel directory walks don't trip EMFILE.
+//!
+//! macOS in particular ships a tiny default soft limit (256), and reindeer's
+//! fork-join walk over many crate source trees can easily exceed it. The
+//! `rlimit` crate handles the OPEN_MAX quirk where requesting `RLIM_INFINITY`
+//! is silently capped at `kern.maxfilesperproc`.
+
+pub fn raise_nofile_limit() {
+    match rlimit::increase_nofile_limit(rlimit::INFINITY) {
+        Ok(new_limit) => log::debug!("RLIMIT_NOFILE soft limit set to {new_limit}"),
+        Err(err) => log::warn!("failed to raise RLIMIT_NOFILE: {err}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raise_does_not_lower_limit() {
+        let (before, _) = rlimit::Resource::NOFILE.get().unwrap();
+        raise_nofile_limit();
+        let (after, _) = rlimit::Resource::NOFILE.get().unwrap();
+        assert!(
+            after >= before,
+            "raise_nofile_limit lowered the limit: {before} -> {after}",
+        );
+    }
+}

--- a/tests/walk_emfile.rs
+++ b/tests/walk_emfile.rs
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Verifies `Globs::walk` surfaces EMFILE rather than silently dropping entries.
+//!
+//! Lives as an integration test because it lowers RLIMIT_NOFILE process-wide
+//! and exhausts file descriptors. Cargo gives each integration-test file its
+//! own binary, so this test runs in a process separate from the unit tests
+//! in `src/`.
+
+use std::fs::File;
+
+use reindeer::glob::GlobSetKind;
+use reindeer::glob::Globs;
+use reindeer::glob::NO_EXCLUDE;
+
+#[test]
+fn walk_propagates_emfile_under_low_rlimit() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let deep = tmp.path().join("a").join("b").join("c").join("d").join("e");
+    std::fs::create_dir_all(&deep).expect("create_dir_all");
+    std::fs::write(deep.join("file.rs"), b"").expect("write file");
+
+    let (_, hard) = rlimit::Resource::NOFILE.get().expect("get nofile");
+    rlimit::Resource::NOFILE
+        .set(64, hard)
+        .expect("lower nofile");
+
+    let mut sentinels = Vec::new();
+    loop {
+        match File::open("/dev/null") {
+            Ok(f) => sentinels.push(f),
+            Err(_) => break,
+        }
+        if sentinels.len() > 200 {
+            break;
+        }
+    }
+    eprintln!("opened {} sentinel files", sentinels.len());
+
+    let globs = Globs::new(GlobSetKind::from_iter(["**/*.rs"]).unwrap(), NO_EXCLUDE);
+    let result = globs.walk(tmp.path());
+    drop(sentinels);
+
+    let err = result.expect_err("walk should have failed under EMFILE");
+    let msg = format!("{err:#}").to_lowercase();
+    eprintln!("got expected error: {msg}");
+    assert!(
+        msg.contains("too many open files") || msg.contains("emfile"),
+        "expected EMFILE-style error, got: {msg}",
+    );
+}


### PR DESCRIPTION
reindeer's fork-join parallelism in do_buckify can hold many open
directory handles concurrently while WalkDir descends crate source
trees. macOS's default soft limit of 256 is easily exceeded, and the
resulting EMFILE errors were being silently dropped (see second commit), causing phantom "unused glob" reports.

Bump the soft limit to the hard limit at startup using the rlimit
crate, which handles the macOS OPEN_MAX quirk where requesting
RLIM_INFINITY is silently capped at kern.maxfilesperproc.

In addition to these changes, we should switch to using a bounded execution strategy, likely using Rayon, rather than unlimited concurrency using the stdlib. That's for a follow-up PR; this one just fixes the critical problems:
- EMFILE was eaten
- The rlimit was too low so it hit EMFILE to begin with

The symptom of the failure we're fixing here is:

```                                                                             
  [ERROR reindeer] Unused globs:                                                                                                                                                     
      fixups/sys-info/fixups.toml line 13: "c/linux.c" matches no files                                                                                                              
      fixups/sys-info/fixups.toml line 14: "c/*.h" matches no files                                                                                                                  
      fixups/sys-info/fixups.toml line 18: "c/darwin.c" matches no files                                                                                                             
      fixups/sys-info/fixups.toml line 19: "c/*.h" matches no files                                                                                                                  
      fixups/sys-info/fixups.toml line 23: "c/windows.c" matches no files                                                                                                            
      fixups/sys-info/fixups.toml line 24: "c/*.h" matches no files                                                                                                                  
      fixups/winapi-x86_64-pc-windows-gnu/fixups.toml line 16: "lib/libwinapi_ole32.a" matches no files                                                                              
      fixups/winapi-x86_64-pc-windows-gnu/fixups.toml line 16: "lib/libwinapi_shell32.a" matches no files                                                                            
      fixups/windows_x86_64_msvc/fixups.toml line 13: "lib/windows.0.48.0.lib" matches no files
```

I figured out why it was happening by telling Claude to add more debug logging. I found out that the debug logging prevented it from happening since it was using `eprintln`(!). Then I tried `sudo fs_usage -w -f reindeer 2>reindeer-fs.log`, and noticed all the fd numbers were in the 200s and put 2 and 2 together surprisingly fast.