### PR TITLE
Restore missing rustversion checksum in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3632,6 +3632,7 @@ dependencies = [
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"


### PR DESCRIPTION
## Summary

`cargo build --locked` currently fails on `main` (and every recent PR) on all platforms:

```
error: cannot update the lock file ... because --locked was passed to prevent this
```

The `rustversion 1.0.14 -> 1.0.22` bump in f174f2d5 dropped the package's `checksum` line from `Cargo.lock` without writing the new one, leaving the lock out of sync with the registry. Any `--locked` invocation (the build/test and release workflows) then aborts because it would need to update the lock to fill in the checksum.

This surfaced first as a Windows-only release failure, but the lock is latently broken on every platform — the "Build and test" workflow has been red on `main` since the bump landed.

## Fix

Restore the single missing `checksum` line for `rustversion 1.0.22`. One line, no version changes.

## Testing

`cargo build --locked` succeeds with the fix applied.
