### PR TITLE
Strip quotes from fake cargo batch args

### DIFF
--- a/src/vendor.rs
+++ b/src/vendor.rs
@@ -348,11 +348,11 @@ mod tests {
         fs::write(
             fake_cargo,
             r#"@echo off
-if not "%1"=="vendor" (
+if not "%~1"=="vendor" (
   echo unexpected args: %* 1>&2
   exit /b 1
 )
-set "vendor_dir=%4"
+set "vendor_dir=%~4"
 mkdir "%vendor_dir%\biscuit-1.0.0"
 (
 echo [package]


### PR DESCRIPTION
Summary: The Windows fake `cargo vendor` script preserved quotes from `%1` and `%4`. When the vendor path was written back into generated Cargo config, `cmd.exe` emitted `directory = ""vendor""`, which made the Windows `cargo test` parse invalid TOML. Use `%~1` and `%~4` to normalize quoted batch args before comparing or embedding them.

Differential Revision: D110921795


