### PR TITLE
feat: add `extra_deps_select` fixup capability

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -439,9 +439,13 @@ visibility = [...]         # list of strings
 [env]                      # map of string to string
 ENVNAME = "..."
 
-[rustc_flags_select]       # map of string (Buck constraint target) to list of strings
+[[rustc_flags_select]]     # map of string (Buck constraint target) to list of strings
 "DEFAULT" = []
 "ovr_config//third-party/python/constraints:3.12" = ["--cfg=Py_3_12"]
+
+[[extra_deps_select]]      # map of string (Buck constraint target) to list of strings (Buck targets)
+"DEFAULT" = []
+"ovr_config//build_mode:asan" = ["//third-party/asan:runtime"]
 
 [buildscript.build]
 extra_deps = [...]         # list of strings (Buck targets)
@@ -495,6 +499,15 @@ ENVNAME = "..."
 - **`extra_deps`** — List of extra dependencies to add. Often other C/C++
   libraries if this is a `-sys` binding package.
   Example: `extra_deps = ["//third-party/zstd:zstd"]`
+
+---
+
+- **`extra_deps_select`** — Buck constraint-dependent extra dependencies. Where
+  `extra_deps` is resolved while generating the BUCK file, these stay
+  conditional in the generated rule, as `deps = [...] + select({...})`. Useful
+  for a dependency Cargo declares under a `cfg` that corresponds to a Buck
+  constraint rather than to a platform, such as a crate's
+  `[target.'cfg(loom)'.dependencies]`. Cannot be platform-specific.
 
 ---
 

--- a/examples/03-complex-fixups/third-party/fixups/libc/fixups.toml
+++ b/examples/03-complex-fixups/third-party/fixups/libc/fixups.toml
@@ -1,1 +1,6 @@
 buildscript.run = true
+
+# Not actually a real dependency of libc, but we need something to exercise the `extra_deps_select` feature
+[[extra_deps_select]]
+"DEFAULT" = []
+"root//config/mode:debug" = ["//third-party:once_cell"]

--- a/src/buck.rs
+++ b/src/buck.rs
@@ -517,7 +517,7 @@ pub struct PlatformRustCommon {
     pub mapped_srcs: BTreeMap<SubtargetOrPath, BuckPath>,
     pub rustc_flags: Select<Vec<String>>,
     pub features: BTreeSet<String>,
-    pub deps: BTreeSet<RuleRef>,
+    pub deps: Select<BTreeSet<RuleRef>>,
     pub named_deps: BTreeMap<String, RuleRef>,
     pub env: BTreeMap<String, StringOrPath>,
 

--- a/src/buckify.rs
+++ b/src/buckify.rs
@@ -924,7 +924,7 @@ fn generate_target_rules<'a>(
             } else if let Some(rename) = rename {
                 recipient.named_deps.insert(rename.to_owned(), dep.clone());
             } else {
-                recipient.deps.insert(dep.clone());
+                recipient.deps.common.insert(dep.clone());
             }
             if let Some(manifest) = manifest {
                 dep_pkgs.push((manifest, dep_kind.target_req()));
@@ -1018,6 +1018,10 @@ fn generate_target_rules<'a>(
         |rule, rustc_flags_select| rule.rustc_flags.selects.push(rustc_flags_select),
     )?;
 
+    // Not platform-specific, so it goes on the base rule rather than through
+    // `evaluate_for_platforms`.
+    base.deps.selects = fixups.compute_extra_deps_select();
+
     evaluate_for_platforms(
         &mut base,
         &mut perplat,
@@ -1085,11 +1089,14 @@ fn generate_target_rules<'a>(
     // Standalone binary - binary for a package always takes the package's library as a dependency
     // if there is one
     if let Some(true) = pkg.dependency_target().map(ManifestTarget::kind_lib) {
-        bin_base.deps.insert(RuleRef::new(if config.buck.split {
-            format!(":{}", tgt_ver)
-        } else {
-            format!(":{}", tgt_disp)
-        }));
+        bin_base
+            .deps
+            .common
+            .insert(RuleRef::new(if config.buck.split {
+                format!(":{}", tgt_ver)
+            } else {
+                format!(":{}", tgt_disp)
+            }));
     }
 
     // Generate rules appropriate to each kind of crate we want to support

--- a/src/fixups.rs
+++ b/src/fixups.rs
@@ -379,6 +379,18 @@ impl<'meta> Fixups<'meta> {
         target_compatible_with_select
     }
 
+    pub fn compute_extra_deps_select(&self) -> Vec<BTreeMap<String, BTreeSet<RuleRef>>> {
+        let mut extra_deps_select = Vec::new();
+
+        for config in self.platform_independent_configs() {
+            if let Some(select) = &config.extra_deps_select {
+                extra_deps_select.extend_from_slice(select);
+            }
+        }
+
+        extra_deps_select
+    }
+
     pub fn precise_srcs(&self) -> bool {
         let mut precise_srcs = None;
 

--- a/src/fixups/config.rs
+++ b/src/fixups/config.rs
@@ -95,6 +95,7 @@ impl FixupConfigFile {
                     compatible_with: None,
                     target_compatible_with: None,
                     target_compatible_with_select: None,
+                    extra_deps_select: None,
                     // Fields that are allowed to be platform-specific:
                     extra_srcs: _,
                     omit_srcs: _,
@@ -127,7 +128,8 @@ impl FixupConfigFile {
                             export_sources, \
                             compatible_with, \
                             target_compatible_with, \
-                            target_compatible_with_select",
+                            target_compatible_with_select, \
+                            extra_deps_select",
                         ));
                     }
                 }
@@ -281,6 +283,10 @@ pub struct FixupConfig {
     /// Additional Buck dependencies
     #[serde(default)]
     pub extra_deps: BTreeSet<String>,
+    /// Select logic for extra_deps. Where `extra_deps` is resolved when the BUCK
+    /// file is generated, these are keyed on Buck constraints and so remain
+    /// conditional in the generated rule.
+    pub extra_deps_select: Option<Vec<BTreeMap<String, BTreeSet<RuleRef>>>>,
     /// Omit Cargo dependencies - just bare crate name
     #[serde(default)]
     pub omit_deps: BTreeSet<String>,


### PR DESCRIPTION
We can already conditionally apply rustc flags based on buck2 constraints through reindeer (`rustc_flags_select`).  This change adds the same capability to `extra_deps`. This makes it possible to properly use crates which  have more complicated conditional dependencies that simply platform specific ones. For example, crates that can  be loom-checked will have `[target.'cfg(loom)'.dependencies]` entries in their Cargo.toml.

To properly model these crates, we transition the graph to a "loom" target where `--cfg loom` is passed to rustc,  but we still need to select the correct dependencies. with `extra_deps_select` we can do that:

```toml
[[extra_deps_select]]
"root//constraints:loom[enabled]" = ["//third-party:loom"]
"DEFAULT" = []
```